### PR TITLE
feat: upgrade to latest deployment

### DIFF
--- a/abis/IExecutionStrategy.json
+++ b/abis/IExecutionStrategy.json
@@ -1,0 +1,335 @@
+[
+  {
+    "inputs": [],
+    "name": "ExecutionFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidPayload",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum ProposalStatus",
+        "name": "status",
+        "type": "uint8"
+      }
+    ],
+    "name": "InvalidProposalStatus",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "snapshotTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "startTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "minEndTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxEndTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "executionPayloadHash",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "addy",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "params",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct Strategy",
+            "name": "executionStrategy",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "author",
+            "type": "address"
+          },
+          {
+            "internalType": "enum FinalizationStatus",
+            "name": "finalizationStatus",
+            "type": "uint8"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "addy",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "params",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct Strategy[]",
+            "name": "votingStrategies",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct Proposal",
+        "name": "proposal",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "votesFor",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "votesAgainst",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "votesAbstain",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "payload",
+        "type": "bytes"
+      }
+    ],
+    "name": "execute",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "snapshotTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "startTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "minEndTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxEndTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "executionPayloadHash",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "addy",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "params",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct Strategy",
+            "name": "executionStrategy",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "author",
+            "type": "address"
+          },
+          {
+            "internalType": "enum FinalizationStatus",
+            "name": "finalizationStatus",
+            "type": "uint8"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "addy",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "params",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct Strategy[]",
+            "name": "votingStrategies",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct Proposal",
+        "name": "proposal",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "votesFor",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "votesAgainst",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "votesAbstain",
+        "type": "uint256"
+      }
+    ],
+    "name": "getProposalStatus",
+    "outputs": [
+      {
+        "internalType": "enum ProposalStatus",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "snapshotTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "startTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "minEndTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxEndTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "executionPayloadHash",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "addy",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "params",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct Strategy",
+            "name": "executionStrategy",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "author",
+            "type": "address"
+          },
+          {
+            "internalType": "enum FinalizationStatus",
+            "name": "finalizationStatus",
+            "type": "uint8"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "addy",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "params",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct Strategy[]",
+            "name": "votingStrategies",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct Proposal",
+        "name": "proposal",
+        "type": "tuple"
+      }
+    ],
+    "name": "getQuorum",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getStrategyType",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/abis/Space.json
+++ b/abis/Space.json
@@ -1,8 +1,16 @@
 [
   {
     "inputs": [
-      { "internalType": "address", "name": "_owner", "type": "address" },
-      { "internalType": "uint32", "name": "_votingDelay", "type": "uint32" },
+      {
+        "internalType": "address",
+        "name": "_controller",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_votingDelay",
+        "type": "uint32"
+      },
       {
         "internalType": "uint32",
         "name": "_minVotingDuration",
@@ -18,15 +26,27 @@
         "name": "_proposalThreshold",
         "type": "uint256"
       },
-      { "internalType": "uint256", "name": "_quorum", "type": "uint256" },
       {
         "components": [
-          { "internalType": "address", "name": "addy", "type": "address" },
-          { "internalType": "bytes", "name": "params", "type": "bytes" }
+          {
+            "internalType": "address",
+            "name": "addy",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
         ],
         "internalType": "struct Strategy[]",
         "name": "_votingStrategies",
         "type": "tuple[]"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "",
+        "type": "bytes[]"
       },
       {
         "internalType": "address[]",
@@ -34,9 +54,21 @@
         "type": "address[]"
       },
       {
-        "internalType": "address[]",
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addy",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Strategy[]",
         "name": "_executionStrategies",
-        "type": "address[]"
+        "type": "tuple[]"
       }
     ],
     "stateMutability": "nonpayable",
@@ -44,26 +76,39 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "auth", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "auth",
+        "type": "address"
+      }
     ],
     "name": "AuthenticatorNotWhitelisted",
     "type": "error"
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "a", "type": "uint256" },
-      { "internalType": "uint256", "name": "b", "type": "uint256" }
+      {
+        "internalType": "uint8",
+        "name": "index",
+        "type": "uint8"
+      }
     ],
     "name": "DuplicateFound",
     "type": "error"
   },
-  { "inputs": [], "name": "EmptyArray", "type": "error" },
-  { "inputs": [], "name": "ExecutionHashMismatch", "type": "error" },
   {
-    "inputs": [
-      { "internalType": "address", "name": "strategy", "type": "address" }
-    ],
+    "inputs": [],
+    "name": "EmptyArray",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "ExecutionStrategyNotWhitelisted",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidCaller",
     "type": "error"
   },
   {
@@ -82,36 +127,94 @@
     "name": "InvalidDuration",
     "type": "error"
   },
-  { "inputs": [], "name": "InvalidProposal", "type": "error" },
-  { "inputs": [], "name": "InvalidVotingStrategyAddress", "type": "error" },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "index", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvalidExecutionStrategyIndex",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidProposal",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidStrategyAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
     ],
     "name": "InvalidVotingStrategyIndex",
     "type": "error"
   },
-  { "inputs": [], "name": "MinVotingDurationHasNotElapsed", "type": "error" },
   {
-    "inputs": [
-      { "internalType": "address", "name": "guard_", "type": "address" }
-    ],
-    "name": "NotIERC165Compliant",
+    "inputs": [],
+    "name": "MinVotingDurationHasNotElapsed",
     "type": "error"
   },
-  { "inputs": [], "name": "ProposalAlreadyExecuted", "type": "error" },
+  {
+    "inputs": [],
+    "name": "ProposalAlreadyFinalized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProposalFinalized",
+    "type": "error"
+  },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "votingPower", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "votingPower",
+        "type": "uint256"
+      }
     ],
     "name": "ProposalThresholdNotReached",
     "type": "error"
   },
-  { "inputs": [], "name": "QuorumNotReachedYet", "type": "error" },
-  { "inputs": [], "name": "UserHasAlreadyVoted", "type": "error" },
-  { "inputs": [], "name": "UserHasNoVotingPower", "type": "error" },
-  { "inputs": [], "name": "VotingPeriodHasEnded", "type": "error" },
-  { "inputs": [], "name": "VotingPeriodHasNotStarted", "type": "error" },
+  {
+    "inputs": [],
+    "name": "QuorumNotReachedYet",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UserHasAlreadyVoted",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UserHasNoVotingPower",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VotingDelayHasPassed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VotingPeriodHasEnded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VotingPeriodHasNotStarted",
+    "type": "error"
+  },
   {
     "anonymous": false,
     "inputs": [
@@ -142,42 +245,35 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": true,
+        "indexed": false,
         "internalType": "address",
-        "name": "previousAvatar",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newAvatar",
+        "name": "newController",
         "type": "address"
       }
     ],
-    "name": "AvatarSet",
+    "name": "ControllerUpdated",
     "type": "event"
   },
   {
     "anonymous": false,
     "inputs": [
       {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addy",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
+        ],
         "indexed": false,
-        "internalType": "address",
-        "name": "guard",
-        "type": "address"
-      }
-    ],
-    "name": "ChangedGuard",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address[]",
+        "internalType": "struct Strategy[]",
         "name": "executionStrategies",
-        "type": "address[]"
+        "type": "tuple[]"
       }
     ],
     "name": "ExecutionStrategiesAdded",
@@ -188,9 +284,9 @@
     "inputs": [
       {
         "indexed": false,
-        "internalType": "address[]",
+        "internalType": "uint8[]",
         "name": "executionStrategies",
-        "type": "address[]"
+        "type": "uint8[]"
       }
     ],
     "name": "ExecutionStrategiesRemoved",
@@ -199,25 +295,6 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint8",
-        "name": "version",
-        "type": "uint8"
-      }
-    ],
-    "name": "Initialized",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "previous",
-        "type": "uint32"
-      },
       {
         "indexed": false,
         "internalType": "uint32",
@@ -244,12 +321,6 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint32",
-        "name": "previous",
-        "type": "uint32"
-      },
       {
         "indexed": false,
         "internalType": "uint32",
@@ -285,18 +356,30 @@
       {
         "indexed": false,
         "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ProposalCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "nextProposalId",
         "type": "uint256"
       },
       {
         "indexed": false,
         "internalType": "address",
-        "name": "proposerAddress",
+        "name": "author",
         "type": "address"
       },
       {
         "components": [
-          { "internalType": "uint256", "name": "quorum", "type": "uint256" },
           {
             "internalType": "uint32",
             "name": "snapshotTimestamp",
@@ -319,18 +402,52 @@
           },
           {
             "internalType": "bytes32",
-            "name": "executionHash",
+            "name": "executionPayloadHash",
             "type": "bytes32"
           },
           {
-            "internalType": "address",
+            "components": [
+              {
+                "internalType": "address",
+                "name": "addy",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "params",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct Strategy",
             "name": "executionStrategy",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "author",
             "type": "address"
           },
           {
             "internalType": "enum FinalizationStatus",
             "name": "finalizationStatus",
             "type": "uint8"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "addy",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "params",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct Strategy[]",
+            "name": "votingStrategies",
+            "type": "tuple[]"
           }
         ],
         "indexed": false,
@@ -347,7 +464,7 @@
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "executionParams",
+        "name": "payload",
         "type": "bytes"
       }
     ],
@@ -362,26 +479,14 @@
         "internalType": "uint256",
         "name": "proposalId",
         "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "enum ProposalOutcome",
-        "name": "outcome",
-        "type": "uint8"
       }
     ],
-    "name": "ProposalFinalized",
+    "name": "ProposalExecuted",
     "type": "event"
   },
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "previous",
-        "type": "uint256"
-      },
       {
         "indexed": false,
         "internalType": "uint256",
@@ -398,9 +503,40 @@
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "previous",
+        "name": "proposalId",
         "type": "uint256"
       },
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "index",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct IndexedStrategy",
+        "name": "newStrategy",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "newMetadataUri",
+        "type": "string"
+      }
+    ],
+    "name": "ProposalUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
       {
         "indexed": false,
         "internalType": "uint256",
@@ -409,25 +545,6 @@
       }
     ],
     "name": "QuorumUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousTarget",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newTarget",
-        "type": "address"
-      }
-    ],
-    "name": "TargetSet",
     "type": "event"
   },
   {
@@ -447,7 +564,11 @@
       },
       {
         "components": [
-          { "internalType": "enum Choice", "name": "choice", "type": "uint8" },
+          {
+            "internalType": "enum Choice",
+            "name": "choice",
+            "type": "uint8"
+          },
           {
             "internalType": "uint256",
             "name": "votingPower",
@@ -458,6 +579,12 @@
         "internalType": "struct Vote",
         "name": "vote",
         "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "voteMetadataUri",
+        "type": "string"
       }
     ],
     "name": "VoteCreated",
@@ -466,12 +593,6 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "previous",
-        "type": "uint256"
-      },
       {
         "indexed": false,
         "internalType": "uint256",
@@ -487,13 +608,27 @@
     "inputs": [
       {
         "components": [
-          { "internalType": "address", "name": "addy", "type": "address" },
-          { "internalType": "bytes", "name": "params", "type": "bytes" }
+          {
+            "internalType": "address",
+            "name": "addy",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
         ],
         "indexed": false,
         "internalType": "struct Strategy[]",
         "name": "votingStrategies",
         "type": "tuple[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes[]",
+        "name": "data",
+        "type": "bytes[]"
       }
     ],
     "name": "VotingStrategiesAdded",
@@ -528,9 +663,21 @@
   {
     "inputs": [
       {
-        "internalType": "address[]",
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addy",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Strategy[]",
         "name": "_executionStrategies",
-        "type": "address[]"
+        "type": "tuple[]"
       }
     ],
     "name": "addExecutionStrategies",
@@ -542,12 +689,25 @@
     "inputs": [
       {
         "components": [
-          { "internalType": "address", "name": "addy", "type": "address" },
-          { "internalType": "bytes", "name": "params", "type": "bytes" }
+          {
+            "internalType": "address",
+            "name": "addy",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
         ],
         "internalType": "struct Strategy[]",
         "name": "_votingStrategies",
         "type": "tuple[]"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "votingStrategyMetadata",
+        "type": "bytes[]"
       }
     ],
     "name": "addVotingStrategies",
@@ -556,50 +716,61 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "avatar",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
-      { "internalType": "uint256", "name": "proposalId", "type": "uint256" },
-      { "internalType": "bytes", "name": "executionParams", "type": "bytes" }
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
     ],
-    "name": "cancelProposal",
+    "name": "cancel",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "proposalId", "type": "uint256" },
-      { "internalType": "bytes", "name": "executionParams", "type": "bytes" }
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "executionPayload",
+        "type": "bytes"
+      }
     ],
-    "name": "finalizeProposal",
+    "name": "execute",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [],
-    "name": "getGuard",
+    "name": "getController",
     "outputs": [
-      { "internalType": "address", "name": "_guard", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "proposalId", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
     ],
     "name": "getProposal",
     "outputs": [
       {
         "components": [
-          { "internalType": "uint256", "name": "quorum", "type": "uint256" },
           {
             "internalType": "uint32",
             "name": "snapshotTimestamp",
@@ -622,18 +793,52 @@
           },
           {
             "internalType": "bytes32",
-            "name": "executionHash",
+            "name": "executionPayloadHash",
             "type": "bytes32"
           },
           {
-            "internalType": "address",
+            "components": [
+              {
+                "internalType": "address",
+                "name": "addy",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "params",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct Strategy",
             "name": "executionStrategy",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "author",
             "type": "address"
           },
           {
             "internalType": "enum FinalizationStatus",
             "name": "finalizationStatus",
             "type": "uint8"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "addy",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "params",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct Strategy[]",
+            "name": "votingStrategies",
+            "type": "tuple[]"
           }
         ],
         "internalType": "struct Proposal",
@@ -646,54 +851,109 @@
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "proposalId", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
     ],
     "name": "getProposalStatus",
     "outputs": [
-      { "internalType": "enum ProposalStatus", "name": "", "type": "uint8" }
+      {
+        "internalType": "enum ProposalStatus",
+        "name": "",
+        "type": "uint8"
+      }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "guard",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "voter",
+        "type": "address"
+      }
+    ],
+    "name": "hasVoted",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "maxVotingDuration",
-    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "minVotingDuration",
-    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "nextProposalId",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "owner",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "proposalThreshold",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -701,23 +961,43 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "proposerAddress",
+        "name": "author",
         "type": "address"
       },
-      { "internalType": "string", "name": "metadataUri", "type": "string" },
+      {
+        "internalType": "string",
+        "name": "metadataUri",
+        "type": "string"
+      },
       {
         "components": [
-          { "internalType": "address", "name": "addy", "type": "address" },
-          { "internalType": "bytes", "name": "params", "type": "bytes" }
+          {
+            "internalType": "uint8",
+            "name": "index",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
         ],
-        "internalType": "struct Strategy",
+        "internalType": "struct IndexedStrategy",
         "name": "executionStrategy",
         "type": "tuple"
       },
       {
         "components": [
-          { "internalType": "uint8", "name": "index", "type": "uint8" },
-          { "internalType": "bytes", "name": "params", "type": "bytes" }
+          {
+            "internalType": "uint8",
+            "name": "index",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
         ],
         "internalType": "struct IndexedStrategy[]",
         "name": "userVotingStrategies",
@@ -730,9 +1010,21 @@
     "type": "function"
   },
   {
-    "inputs": [],
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
     "name": "quorum",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -752,9 +1044,9 @@
   {
     "inputs": [
       {
-        "internalType": "address[]",
+        "internalType": "uint8[]",
         "name": "_executionStrategies",
-        "type": "address[]"
+        "type": "uint8[]"
       }
     ],
     "name": "removeExecutionStrategies",
@@ -766,7 +1058,7 @@
     "inputs": [
       {
         "internalType": "uint8[]",
-        "name": "indicesToRemove",
+        "name": "_votingStrategyIndices",
         "type": "uint8[]"
       }
     ],
@@ -784,18 +1076,13 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_avatar", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_controller",
+        "type": "address"
+      }
     ],
-    "name": "setAvatar",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "_guard", "type": "address" }
-    ],
-    "name": "setGuard",
+    "name": "setController",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -815,7 +1102,11 @@
   },
   {
     "inputs": [
-      { "internalType": "string", "name": "_metadataUri", "type": "string" }
+      {
+        "internalType": "string",
+        "name": "_metadataUri",
+        "type": "string"
+      }
     ],
     "name": "setMetadataUri",
     "outputs": [],
@@ -837,7 +1128,11 @@
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "_threshold", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "_proposalThreshold",
+        "type": "uint256"
+      }
     ],
     "name": "setProposalThreshold",
     "outputs": [],
@@ -846,34 +1141,11 @@
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "_quorum", "type": "uint256" }
-    ],
-    "name": "setQuorum",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "_target", "type": "address" }
-    ],
-    "name": "setTarget",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes", "name": "initializeParams", "type": "bytes" }
-    ],
-    "name": "setUp",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint32", "name": "_votingDelay", "type": "uint32" }
+      {
+        "internalType": "uint32",
+        "name": "_votingDelay",
+        "type": "uint32"
+      }
     ],
     "name": "setVotingDelay",
     "outputs": [],
@@ -881,15 +1153,12 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "target",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
-      { "internalType": "address", "name": "newOwner", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
     ],
     "name": "transferOwnership",
     "outputs": [],
@@ -898,17 +1167,82 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "voterAddress", "type": "address" },
-      { "internalType": "uint256", "name": "proposalId", "type": "uint256" },
-      { "internalType": "enum Choice", "name": "choice", "type": "uint8" },
+      {
+        "internalType": "address",
+        "name": "author",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
       {
         "components": [
-          { "internalType": "uint8", "name": "index", "type": "uint8" },
-          { "internalType": "bytes", "name": "params", "type": "bytes" }
+          {
+            "internalType": "uint8",
+            "name": "index",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IndexedStrategy",
+        "name": "executionStrategy",
+        "type": "tuple"
+      },
+      {
+        "internalType": "string",
+        "name": "metadataUri",
+        "type": "string"
+      }
+    ],
+    "name": "updateProposal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "voterAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "enum Choice",
+        "name": "choice",
+        "type": "uint8"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "index",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
         ],
         "internalType": "struct IndexedStrategy[]",
         "name": "userVotingStrategies",
         "type": "tuple[]"
+      },
+      {
+        "internalType": "string",
+        "name": "voteMetadataUri",
+        "type": "string"
       }
     ],
     "name": "vote",
@@ -919,7 +1253,13 @@
   {
     "inputs": [],
     "name": "votingDelay",
-    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   }

--- a/abis/SpaceFactory.json
+++ b/abis/SpaceFactory.json
@@ -45,9 +45,9 @@
       },
       {
         "indexed": false,
-        "internalType": "uint256",
-        "name": "quorum",
-        "type": "uint256"
+        "internalType": "string",
+        "name": "metadataUri",
+        "type": "string"
       },
       {
         "components": [
@@ -69,15 +69,33 @@
       },
       {
         "indexed": false,
+        "internalType": "bytes[]",
+        "name": "votingStrategyMetadata",
+        "type": "bytes[]"
+      },
+      {
+        "indexed": false,
         "internalType": "address[]",
         "name": "authenticators",
         "type": "address[]"
       },
       {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addy",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
+        ],
         "indexed": false,
-        "internalType": "address[]",
-        "name": "executionStrategiesAddresses",
-        "type": "address[]"
+        "internalType": "struct Strategy[]",
+        "name": "executionStrategies",
+        "type": "tuple[]"
       }
     ],
     "name": "SpaceCreated",
@@ -111,9 +129,9 @@
         "type": "uint256"
       },
       {
-        "internalType": "uint256",
-        "name": "quorum",
-        "type": "uint256"
+        "internalType": "string",
+        "name": "metadataUri",
+        "type": "string"
       },
       {
         "components": [
@@ -133,14 +151,31 @@
         "type": "tuple[]"
       },
       {
+        "internalType": "bytes[]",
+        "name": "votingStrategyMetadata",
+        "type": "bytes[]"
+      },
+      {
         "internalType": "address[]",
         "name": "authenticators",
         "type": "address[]"
       },
       {
-        "internalType": "address[]",
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addy",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "params",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Strategy[]",
         "name": "executionStrategies",
-        "type": "address[]"
+        "type": "tuple[]"
       },
       {
         "internalType": "bytes32",

--- a/schema.graphql
+++ b/schema.graphql
@@ -17,6 +17,7 @@ type Space @entity {
   strategies_params: [String!]!
   authenticators: [Bytes!]!
   executors: [Bytes!]!
+  executors_types: [String!]!
   proposal_count: Int!
   vote_count: Int!
   created: Int!
@@ -48,6 +49,7 @@ type Proposal @entity {
   created: Int!
   tx: Bytes!
   vote_count: Int!
+  executed: Boolean!
 }
 
 type Vote @entity {

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -1,9 +1,48 @@
-import { BigDecimal, Bytes, ipfs, json } from '@graphprotocol/graph-ts'
+import { Address, BigDecimal, BigInt, Bytes, ipfs, json } from '@graphprotocol/graph-ts'
 import { JSON } from 'assemblyscript-json'
 import { SpaceCreated } from '../generated/SpaceFactory/SpaceFactory'
-import { ProposalCreated, VoteCreated, MetadataUriUpdated } from '../generated/Space/Space'
+import { IExecutionStrategy } from '../generated/SpaceFactory/IExecutionStrategy'
+import {
+  Space as SpaceContract,
+  ProposalCreated,
+  ProposalExecuted,
+  VoteCreated,
+  MetadataUriUpdated,
+} from '../generated/templates/Space/Space'
 import { Space as SpaceTemplate } from '../generated/templates'
 import { Space, Proposal, Vote, User } from '../generated/schema'
+
+function updateSpaceMetadata(space: Space, metadataUri: string): void {
+  if (!metadataUri.startsWith('ipfs://')) return
+
+  let hash = metadataUri.slice(7)
+  let data = ipfs.cat(hash)
+
+  let value = json.try_fromBytes(data as Bytes)
+  let obj = value.value.toObject()
+  let name = obj.get('name')
+  let description = obj.get('description')
+  let externalUrl = obj.get('external_url')
+  let properties = obj.get('properties')
+
+  if (name) space.name = name.toString()
+  if (description) space.about = description.toString()
+  if (externalUrl) space.external_url = externalUrl.toString()
+
+  if (properties) {
+    const propertiesObj = properties.toObject()
+
+    let github = propertiesObj.get('github')
+    let twitter = propertiesObj.get('twitter')
+    let discord = propertiesObj.get('discord')
+    let wallets = propertiesObj.get('wallets')
+
+    if (github) space.github = github.toString()
+    if (twitter) space.twitter = twitter.toString()
+    if (discord) space.discord = discord.toString()
+    if (wallets && wallets.toArray().length > 0) space.wallet = wallets.toArray()[0].toString()
+  }
+}
 
 export function handleSpaceCreated(event: SpaceCreated): void {
   let space = new Space(event.params.space.toHexString())
@@ -14,17 +53,30 @@ export function handleSpaceCreated(event: SpaceCreated): void {
   space.min_voting_period = event.params.minVotingDuration.toI32()
   space.max_voting_period = event.params.maxVotingDuration.toI32()
   space.proposal_threshold = event.params.proposalThreshold.toBigDecimal()
-  space.quorum = event.params.quorum.toBigDecimal()
+  space.quorum = new BigDecimal(new BigInt(0))
   space.strategies = event.params.votingStrategies.map<Bytes>((strategy) => strategy.addy)
   space.strategies_params = event.params.votingStrategies.map<string>((strategy) =>
     strategy.params.toHexString()
   )
   space.authenticators = event.params.authenticators.map<Bytes>((address) => address)
-  space.executors = event.params.executionStrategiesAddresses.map<Bytes>((address) => address)
+  space.executors = event.params.executionStrategies.map<Bytes>((strategy) => strategy.addy)
   space.proposal_count = 0
   space.vote_count = 0
   space.created = event.block.timestamp.toI32()
   space.tx = event.transaction.hash
+
+  space.executors_types = event.params.executionStrategies.map<string>((strategy) => {
+    let executionStrategyContract = IExecutionStrategy.bind(
+      Address.fromString(strategy.addy.toHexString())
+    )
+
+    let typeResult = executionStrategyContract.try_getStrategyType()
+    if (typeResult.reverted) return ''
+    return typeResult.value
+  })
+
+  updateSpaceMetadata(space, event.params.metadataUri)
+
   space.save()
 
   SpaceTemplate.create(event.params.space)
@@ -41,8 +93,8 @@ export function handleProposalCreated(event: ProposalCreated): void {
   let proposal = new Proposal(`${space.id}/${event.params.nextProposalId}`)
   proposal.proposal_id = event.params.nextProposalId.toI32()
   proposal.space = space.id
-  proposal.author = event.params.proposerAddress.toHexString()
-  proposal.execution_hash = event.params.proposal.executionHash.toHexString()
+  proposal.author = event.params.author.toHexString()
+  proposal.execution_hash = event.params.proposal.executionPayloadHash.toHexString()
   proposal.metadata_uri = metadataUri
   proposal.title = ''
   proposal.body = ''
@@ -58,10 +110,15 @@ export function handleProposalCreated(event: ProposalCreated): void {
   proposal.scores_2 = BigDecimal.fromString('0')
   proposal.scores_3 = BigDecimal.fromString('0')
   proposal.scores_total = BigDecimal.fromString('0')
-  proposal.quorum = event.params.proposal.quorum.toBigDecimal()
   proposal.created = event.block.timestamp.toI32()
   proposal.tx = event.transaction.hash
   proposal.vote_count = 0
+
+  let spaceContract = SpaceContract.bind(Address.fromString(space.id))
+  let quorumResult = spaceContract.try_quorum(event.params.nextProposalId)
+  if (!quorumResult.reverted) {
+    proposal.quorum = new BigDecimal(quorumResult.value)
+  }
 
   if (metadataUri.startsWith('ipfs://')) {
     let hash = metadataUri.slice(7)
@@ -92,9 +149,9 @@ export function handleProposalCreated(event: ProposalCreated): void {
   space.proposal_count += 1
   space.save()
 
-  let user = User.load(event.params.proposerAddress.toHexString())
+  let user = User.load(event.params.author.toHexString())
   if (user == null) {
-    user = new User(event.params.proposerAddress.toHexString())
+    user = new User(event.params.author.toHexString())
     user.proposal_count = 0
     user.vote_count = 0
     user.created = event.block.timestamp.toI32()
@@ -104,13 +161,29 @@ export function handleProposalCreated(event: ProposalCreated): void {
   user.save()
 }
 
+export function handleProposalExecuted(event: ProposalExecuted): void {
+  let proposal = Proposal.load(`${event.address.toHexString()}/${event.params.proposalId}`)
+  if (proposal == null) {
+    return
+  }
+
+  proposal.executed = true
+
+  proposal.save()
+}
+
 export function handleVoteCreated(event: VoteCreated): void {
   let space = Space.load(event.address.toHexString())
   if (space == null) {
     return
   }
 
-  let choice = event.params.vote.choice + 1
+  // Swap For/Against
+  let choice = event.params.vote.choice
+  if (event.params.vote.choice === 0) choice = 2
+  if (event.params.vote.choice === 1) choice = 1
+  if (event.params.vote.choice === 2) choice = 3
+
   let vp = event.params.vote.votingPower.toBigDecimal()
 
   let vote = new Vote(
@@ -156,39 +229,7 @@ export function handleMetadataUriUpdated(event: MetadataUriUpdated): void {
     return
   }
 
-  let metadataUri = event.params.newMetadataUri
-
-  if (metadataUri.startsWith('ipfs://')) {
-    let hash = metadataUri.slice(7)
-    let data = ipfs.cat(hash)
-
-    if (data !== null) {
-      let value = json.try_fromBytes(data as Bytes)
-      let obj = value.value.toObject()
-      let name = obj.get('name')
-      let description = obj.get('description')
-      let externalUrl = obj.get('external_url')
-      let properties = obj.get('properties')
-
-      if (name) space.name = name.toString()
-      if (description) space.about = description.toString()
-      if (externalUrl) space.external_url = externalUrl.toString()
-
-      if (properties) {
-        const propertiesObj = properties.toObject()
-
-        let github = propertiesObj.get('github')
-        let twitter = propertiesObj.get('twitter')
-        let discord = propertiesObj.get('discord')
-        let wallets = propertiesObj.get('wallets')
-
-        if (github) space.github = github.toString()
-        if (twitter) space.twitter = twitter.toString()
-        if (discord) space.discord = discord.toString()
-        if (wallets && wallets.toArray().length > 0) space.wallet = wallets.toArray()[0].toString()
-      }
-    }
-  }
+  updateSpaceMetadata(space, event.params.newMetadataUri)
 
   space.save()
 }

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -6,9 +6,9 @@ dataSources:
     name: SpaceFactory
     network: goerli
     source:
-      address: '0xf8d933026b7bD549314A31E6c5b2616c631A9E87'
+      address: '0xfC38E50eA8fc64Fb68B9fece13b16404B8D43864'
       abi: SpaceFactory
-      startBlock: 8501860
+      startBlock: 8577681
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.5
@@ -18,8 +18,10 @@ dataSources:
       abis:
         - name: SpaceFactory
           file: ./abis/SpaceFactory.json
+        - name: IExecutionStrategy
+          file: ./abis/IExecutionStrategy.json
       eventHandlers:
-        - event: SpaceCreated(address,address,uint32,uint32,uint32,uint256,uint256,(address,bytes)[],address[],address[])
+        - event: SpaceCreated(address,address,uint32,uint32,uint32,uint256,string,(address,bytes)[],bytes[],address[],(address,bytes)[])
           handler: handleSpaceCreated
       file: ./src/mapping.ts
 templates:
@@ -40,9 +42,11 @@ templates:
         - name: Space
           file: ./abis/Space.json
       eventHandlers:
-        - event: ProposalCreated(uint256,address,(uint256,uint32,uint32,uint32,uint32,bytes32,address,uint8),string,bytes)
+        - event: ProposalCreated(uint256,address,(uint32,uint32,uint32,uint32,bytes32,(address,bytes),address,uint8,(address,bytes)[]),string,bytes)
           handler: handleProposalCreated
-        - event: VoteCreated(uint256,address,(uint8,uint256))
+        - event: ProposalExecuted(uint256)
+          handler: handleProposalExecuted
+        - event: VoteCreated(uint256,address,(uint8,uint256),string)
           handler: handleVoteCreated
         - event: MetadataUriUpdated(string)
           handler: handleMetadataUriUpdated


### PR DESCRIPTION
Changes:
- Add `executors_types` read from IExecutionStrategy
- Quorum at proposal level read from space/strategy.
- Adjust For/Against/Abstain choices
- Handle executed event.
- Index metadataUri at space creation.

Already deployed.