### PR TITLE
feat: index strategies_metadata

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -15,6 +15,7 @@ type Space @entity {
   quorum: BigDecimal!
   strategies: [Bytes!]!
   strategies_params: [String!]!
+  strategies_metadata: [String!]!
   authenticators: [Bytes!]!
   executors: [Bytes!]!
   executors_types: [String!]!

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -58,6 +58,9 @@ export function handleSpaceCreated(event: SpaceCreated): void {
   space.strategies_params = event.params.votingStrategies.map<string>((strategy) =>
     strategy.params.toHexString()
   )
+  space.strategies_metadata = event.params.votingStrategyMetadata.map<string>((metadata) =>
+    metadata.toHexString()
+  )
   space.authenticators = event.params.authenticators.map<Bytes>((address) => address)
   space.executors = event.params.executionStrategies.map<Bytes>((strategy) => strategy.addy)
   space.proposal_count = 0


### PR DESCRIPTION
`strategies_metadata` is used to store decimals to interpret voting power on UI
