### PR TITLE
feat: add execution_tx

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -69,6 +69,7 @@ type Proposal @entity {
   quorum: BigDecimal!
   created: Int!
   tx: Bytes!
+  execution_tx: Bytes
   vote_count: Int!
   executed: Boolean!
   completed: Boolean!

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -212,6 +212,7 @@ export function handleProposalExecuted(event: ProposalExecuted): void {
       executionStrategy.type == 'SimpleQuorumAvatar'
     ) {
       proposal.completed = true
+      proposal.execution_tx = event.transaction.hash
     }
 
     if (executionStrategy.type == 'SimpleQuorumTimelock') {
@@ -297,5 +298,6 @@ export function handleTimelockProposalExecuted(event: TimelockProposalExecuted):
   }
 
   proposal.completed = true
+  proposal.execution_tx = event.transaction.hash
   proposal.save()
 }


### PR DESCRIPTION
Depends on https://github.com/snapshot-labs/sx-subgraph/pull/13

This PR tracks `execution_tx` (transaction where execution actually occurred, not necessarily transaction with `execute` call).