### PR TITLE
feat: support Polygon and Arbitrum

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -11,6 +11,18 @@
       "startBlock": 3961351
     }
   },
+  "matic": {
+    "ProxyFactory": {
+      "address": "0x4b4f7f64be813ccc66aefc3bfce2baa01188631c",
+      "startBlock": 45499032
+    }
+  },
+  "arbitrum-one": {
+    "ProxyFactory": {
+      "address": "0x4b4f7f64be813ccc66aefc3bfce2baa01188631c",
+      "startBlock": 114776723
+    }
+  },
   "linea-testnet": {
     "ProxyFactory": {
       "address": "0x12A1FfFFfd70677939D61d641eA043bc9060c718",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "deploy-goerli": "graph deploy --node https://api.thegraph.com/deploy/ snapshot-labs/sx-subgraph",
     "deploy-linea-testnet": "graph deploy --network linea-testnet --studio sx-linea-testnet",
     "deploy-studio-goerli": "graph deploy --network goerli --studio sx-goerli",
-    "deploy-studio-sepolia": "graph deploy --network sepolia --studio sx-sepolia"
+    "deploy-studio-sepolia": "graph deploy --network sepolia --studio sx-sepolia",
+    "deploy-studio-polygon": "graph deploy --network matic --studio sx-polygon",
+    "deploy-studio-arbitrum": "graph deploy --network arbitrum-one --studio sx-arbitrum"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.50.1",


### PR DESCRIPTION
Add support for Polygon and Arbitrum. These subgraphs are already deployed.