### PR TITLE
chore: update mainnet to use v1.0.3 deployment

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -2,31 +2,31 @@
   "mainnet": {
     "ProxyFactory": {
       "address": "0x4b4f7f64be813ccc66aefc3bfce2baa01188631c",
-      "startBlock": 18426159
+      "startBlock": 18962278
     }
   },
   "goerli": {
     "ProxyFactory": {
       "address": "0x4b4f7f64be813ccc66aefc3bfce2baa01188631c",
-      "startBlock": 9405311
+      "startBlock": 9893638
     }
   },
   "sepolia": {
     "ProxyFactory": {
       "address": "0x4b4f7f64be813ccc66aefc3bfce2baa01188631c",
-      "startBlock": 3961351
+      "startBlock": 4519171
     }
   },
   "matic": {
     "ProxyFactory": {
       "address": "0x4b4f7f64be813ccc66aefc3bfce2baa01188631c",
-      "startBlock": 45499032
+      "startBlock": 50858232
     }
   },
   "arbitrum-one": {
     "ProxyFactory": {
       "address": "0x4b4f7f64be813ccc66aefc3bfce2baa01188631c",
-      "startBlock": 114776723
+      "startBlock": 157825417
     }
   },
   "linea-testnet": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sx-subgraph",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -1,4 +1,4 @@
-import {Address, BigDecimal, BigInt, Bytes, dataSource } from '@graphprotocol/graph-ts'
+import { Address, BigDecimal, BigInt, Bytes, dataSource } from '@graphprotocol/graph-ts'
 import { ProxyDeployed } from '../generated/ProxyFactory/ProxyFactory'
 import { AvatarExecutionStrategy } from '../generated/ProxyFactory/AvatarExecutionStrategy'
 import { TimelockExecutionStrategy } from '../generated/ProxyFactory/TimelockExecutionStrategy'
@@ -33,15 +33,11 @@ import {
 import { Space, ExecutionStrategy, ExecutionHash, Proposal, Vote, User } from '../generated/schema'
 import { updateStrategiesParsedMetadata, updateProposalValidationStrategy } from './helpers'
 
-let MASTER_SPACE = Address.fromString('0xC3031A7d3326E47D49BfF9D374d74f364B29CE4D')
-let MASTER_SIMPLE_QUORUM_AVATAR = Address.fromString('0xecE4f6b01a2d7FF5A9765cA44162D453fC455e42')
-let MASTER_SIMPLE_QUORUM_TIMELOCK = Address.fromString('0xf2A1C2f2098161af98b2Cc7E382AB7F3ba86Ebc4')
-
-if (dataSource.network() == 'mainnet') {
-  MASTER_SPACE = Address.fromString('0xd9c46d5420434355d0E5Ca3e3cCb20cE7A533964')
-  MASTER_SIMPLE_QUORUM_AVATAR = Address.fromString('0x3813f3d97Aa2F80e3aF625605A31206e067FB2e5')
-  MASTER_SIMPLE_QUORUM_TIMELOCK = Address.fromString('0x3813f3d97Aa2F80e3aF625605A31206e067FB2e5')
-}
+const MASTER_SPACE = Address.fromString('0xC3031A7d3326E47D49BfF9D374d74f364B29CE4D')
+const MASTER_SIMPLE_QUORUM_AVATAR = Address.fromString('0xecE4f6b01a2d7FF5A9765cA44162D453fC455e42')
+const MASTER_SIMPLE_QUORUM_TIMELOCK = Address.fromString(
+  '0xf2A1C2f2098161af98b2Cc7E382AB7F3ba86Ebc4'
+)
 
 export function handleProxyDeployed(event: ProxyDeployed): void {
   if (event.params.implementation.equals(MASTER_SPACE)) {


### PR DESCRIPTION
Also rewinded start blocks so we don't rescan blocks that won't have spaces with new master space created (new start blocks are blocks at which master space contract was deployed).